### PR TITLE
fix: release pipeline with explicit link to GH API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_API_URL: https://api.github.com
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: asyncapi-bot
           GIT_AUTHOR_EMAIL: info@asyncapi.io


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Trying to fix failing pipeline. Internets say only that you get error `An error occurred while running semantic-release: RequestError [HttpError]: Cookies must be enabled to use GitHub.` when you call `github.com` instead of `api.github.com`. It would make sense if all release pipelines would fail, but trying to pass `api.github.com` anyway