### PR TITLE
fix: remove manual api link specification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          GITHUB_API_URL: https://api.github.com
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: asyncapi-bot
           GIT_AUTHOR_EMAIL: info@asyncapi.io


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Request still goes to wrong address so removing previous change to not confuse anyone in future
```
 request: {
    method: 'POST',
    url: 'https://github.com/repos/asyncapi/python-paho-template/releases',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'octokit-rest.js/17.6.0 octokit-core.js/2.5.0 Node.js/13.14.0 (Linux 5.3; x64)',
      authorization: 'token [REDACTED]',
      'content-type': 'application/json; charset=utf-8'
    },
```
I think issue was caused by lack of releases but with tags in place, this is unexpected combination. I now manually create release for previous tags. Let's see