### PR TITLE
Fix call to channel.ext to pass a string. Closes #32.

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -293,7 +293,7 @@ const getMethods = (obj) => {
 function getFunctionNameByChannel(channelName, channel) {
   let ret = _.camelCase(channelName);
   //console.log('functionName channel: ' + JSON.stringify(channelJson));
-  let functionName = channel.ext(['x-function-name']);
+  let functionName = channel.ext('x-function-name');
   //console.log('function name for channel ' + channelName + ': ' + functionName);
   if (functionName) {
     ret = functionName;


### PR DESCRIPTION
Possible fix for #32. As there are no unit tests I have no idea on what other things this might break.