### PR TITLE
chore: add bot to codeowner so human doesn't not have to approve bot's work

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the "@asyncapi/python-paho-template" repository. The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @damaru-inc @derberg @fmvilas
+* @damaru-inc @derberg @fmvilas @github-actions[bot]


### PR DESCRIPTION
@damaru-inc this is needed otherwise all update in workflows or dependabot updates to packages will have to wait for our approval even though bot can do it and automerge handle it