### PR TITLE
fix: when there are no schema properties, we add 'pass' to the constructor

### DIFF
--- a/partials/model-class
+++ b/partials/model-class
@@ -27,8 +27,9 @@
 ):
 {%- for name, prop in properties -%}
 {%- set typeInfo = [name, prop] | getTypeInfo %}
-{{ indent3}}self.{{typeInfo.pythonName}} = {{typeInfo.pythonName}}
+{{ indent3 }}self.{{typeInfo.pythonName}} = {{typeInfo.pythonName}}
+{%- else %}
+{{ indent3 }}pass
 {%- endfor %}
-
 
 {% endmacro -%}


### PR DESCRIPTION

**Description**

In cases where a schema has no properties, the model class ends up with a constructor looking like this:

```
def __init__ (self):
```
which is invalid. This fix adds 'pass' : 
def __init__ (self):
  pass

**Related issue(s)**
Fixes #60 
